### PR TITLE
feat: add GitHub repo shortcut in app header

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -32,6 +32,14 @@ export default async function Home() {
         >
           docs
         </Link>
+        <a
+          href="https://github.com/xo-toybox/signal-capture"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs font-mono text-[#525252] hover:text-[#737373] transition-colors"
+        >
+          github
+        </a>
       </header>
 
       <Suspense fallback={null}>


### PR DESCRIPTION
Adds a `github` link in the home page header next to the existing `docs` link, opening the repository in a new tab.

Closes #11

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely a UI/navigation change with no impact to data handling or application logic.
> 
> **Overview**
> Adds a `github` outbound link to the home page header (`src/app/(app)/page.tsx`) alongside the existing `docs` link, opening the repository in a new tab with proper `rel` attributes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6c02d6332cc62258e3977f638890d6845be3be4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GitHub repository link in the header navigation, positioned next to the documentation link for quick access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->